### PR TITLE
Explicitly specifying file encoding when opening a file with Python. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- [proselint](https://github.com/amperser/proselint) tool plugin and tests. (Thomas Denewiler, @tdenewiler, #38, #39)
+- [write-good](https://github.com/btford/write-good) tool plugin and tests. (Thomas Denewiler, @tdenewiler, #41)
 - reStructuredText discovery plugin and tests.
 - [rstcheck](https://github.com/myint/rstcheck) tool plugin and tests.
 - [rst-lint](https://github.com/twolfson/restructuredtext-lint) tool plugin and tests.
 
 ### Fixed
+
+- Specifying an encoding when calling open (pylint: W1514).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- Specifying an encoding when calling open (pylint: W1514).
+- Specifying an encoding when calling open (pylint: [W1514](https://pylint.pycqa.org/en/latest/technical_reference/features.html)).
 
 ### Removed
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 
 from setuptools import setup
 
-with open("README.md", encoding="utf8") as f:
-    long_description = f.read()  # pylint: disable=invalid-name
+with open("README.md", encoding="utf8") as fid:
+    long_description = fid.read()  # pylint: disable=invalid-name
 
 TEST_DEPS = [
     "mock",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding="utf8") as f:
     long_description = f.read()  # pylint: disable=invalid-name
 
 TEST_DEPS = [

--- a/src/statick_md/plugins/tool/markdownlint_tool_plugin.py
+++ b/src/statick_md/plugins/tool/markdownlint_tool_plugin.py
@@ -67,7 +67,7 @@ class MarkdownlintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 

--- a/src/statick_md/plugins/tool/proselint_tool_plugin.py
+++ b/src/statick_md/plugins/tool/proselint_tool_plugin.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import proselint
+from proselint.config import default as proselint_default
 
 from statick_tool.issue import Issue
 from statick_tool.package import Package
@@ -41,14 +42,16 @@ class ProselintToolPlugin(ToolPlugin):  # type: ignore
         # https://github.com/amperser/proselint/issues/355
         output: Dict[str, Any] = {}
         for filename in files:
-            with open(filename) as fid:
-                errors = proselint.tools.errors_to_json(proselint.tools.lint(fid))
+            with open(filename, encoding="utf8") as fid:
+                errors = proselint.tools.errors_to_json(
+                    proselint.tools.lint(fid, config=proselint_default)
+                )
                 output[filename] = errors
 
         for key, value in output.items():
             logging.debug("%s: %s", key, value)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for key, value in output.items():
                 combined = key + value
                 fid.write(combined)

--- a/src/statick_md/plugins/tool/rstcheck_tool_plugin.py
+++ b/src/statick_md/plugins/tool/rstcheck_tool_plugin.py
@@ -57,7 +57,7 @@ class RstcheckToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", str(output))
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(str(output))
 

--- a/src/statick_md/plugins/tool/rstlint_tool_plugin.py
+++ b/src/statick_md/plugins/tool/rstlint_tool_plugin.py
@@ -38,7 +38,7 @@ class RstlintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", str(output))
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(str(output))
 

--- a/src/statick_md/plugins/tool/writegood_tool_plugin.py
+++ b/src/statick_md/plugins/tool/writegood_tool_plugin.py
@@ -61,7 +61,7 @@ class WriteGoodToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 


### PR DESCRIPTION
…Fixes pylint warning. Updating proselint api call to use new default config object. Updating changelog.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>