### PR TITLE
Updated yaml format

### DIFF
--- a/rsc/md-config.yaml
+++ b/rsc/md-config.yaml
@@ -68,7 +68,8 @@ levels:
         flags: ""
 
   md_with_pylint:
-    inherits_from: "md"
+    inherits_from:
+        - "md"
     discovery:
       python:
         flags: ""

--- a/rsc/md-config.yaml
+++ b/rsc/md-config.yaml
@@ -69,7 +69,7 @@ levels:
 
   md_with_pylint:
     inherits_from:
-        - "md"
+      - "md"
     discovery:
       python:
         flags: ""


### PR DESCRIPTION
I had issues running with this config in statick-action using the deprecated format for "inherits_from".  This seems to fix it.

To test use a line like this:  (running statick with default Markdown configuration on this repo itself)
`
statick --output-directory /tmp --profile md-profile.yaml --config md-config.yaml --user-paths ~/src/statick_md  .`

This is using v0.8.1 of statick and the 'main' branch of statick-md.  

As an aside, none of the default configs in statick itself or statick-tooling appear to use the suggested new method.   Should that be changed?

I did not attempt to solve the underlying issue with the old string method.

