### PR TITLE
Cleanup supported versions.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,17 +9,17 @@ on: # NOLINT
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
@@ -27,7 +27,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
@@ -53,12 +53,12 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TEST_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,6 +65,13 @@ jobs:
           python -m pip install --upgrade tox-gh-actions
           python -m pip install --upgrade virtualenv
 
+      # Have to install newer version from non-apt source due to SSL library compatibility issues.
+      - name: Install Node and node-based tools (Linux)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
+        run: |
+          npm install -g markdownlint-cli
+          npm install -g write-good
+
       - name: Mypy
         run: |
           mypy --ignore-missing-imports --strict src/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-20.04, ubuntu-22.04, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -61,19 +61,9 @@ jobs:
           python -m pip install --upgrade coverage
           python -m pip install --upgrade mypy
           python -m pip install --upgrade types-docutils
-          python -m pip install --upgrade statick
-          python -m pip install --upgrade statick-md
           python -m pip install --upgrade tox
           python -m pip install --upgrade tox-gh-actions
           python -m pip install --upgrade virtualenv
-          python -m pip install -r requirements.txt
-
-      # Have to install newer version from non-apt source due to SSL library compatibility issues.
-      - name: Install Node and node-based tools (Linux)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
-        run: |
-          npm install -g markdownlint-cli
-          npm install -g write-good
 
       - name: Mypy
         run: |
@@ -90,11 +80,14 @@ jobs:
 
       - name: Statick Documentation
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
-        run: |
-          statick . --check --user-paths . --profile documentation.yaml
+        uses: sscpac/statick-action@v0.9.2
+        with:
+          profile: documentation.yaml
+          timings: true
 
       - name: Self check
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
-        run: |
-          mkdir statick-output
-          statick . --output-directory statick-output --check --profile self_check.yaml
+        uses: sscpac/statick-action@v0.9.2
+        with:
+          profile: self_check.yaml
+          timings: true

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     url="https://github.com/sscpac/statick-md",
     classifiers=[
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
@@ -24,7 +24,6 @@ line_length = 88
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
- Drop support for Python 3.7 due to end-of-life on 27 June 2023.
- Run deployment actions on ubuntu-latest.
- Make setup.py and tox.ini consistent with supported versions.
- Use latest tagged releases for GitHub Actions.