### PR TITLE
Remove use of flake8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,7 @@ envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
-flake8-max-line-length = 9000
 norecursedirs = .tox
-
-# To work with black some items must be ignored.
-# https://github.com/psf/black#how-black-wraps-lines
-[flake8]
-exclude = .tox
-ignore = E203, E231, W503
 
 # To work with black a specific configuration is required.
 # https://github.com/psf/black#how-black-wraps-lines
@@ -34,19 +27,16 @@ changedir = {toxinidir}/output-{envname}
 passenv = CI
 setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps =
-    flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
-    flake8-pep3101
-    pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
+    pycodestyle
     pydocstyle
     pytest
     pytest-cov
-    pytest-flake8
     pytest-isort
     .[test]
 commands =
     pydocstyle ../src/
     pycodestyle --ignore=E203,E501,W503 ../src/
-    pytest --flake8 --isort \
+    pytest --isort \
         --cov=statick_tool.plugins.discovery.markdown_discovery_plugin \
         --cov=statick_tool.plugins.discovery.rst_discovery_plugin \
         --cov=statick_tool.plugins.tool.markdownlint_tool_plugin \


### PR DESCRIPTION
The flake8 project is marked as abandoned. There are some forks but none that do not cause unsolved issues for our code base.